### PR TITLE
Refactor Hathifiles queries

### DIFF
--- a/lib/ht_traject/ht_dbh.rb
+++ b/lib/ht_traject/ht_dbh.rb
@@ -4,7 +4,7 @@ require 'sequel'
 module HathiTrust
   module DBH
     extend HathiTrust::SecureData
-    DB = Sequel.connect("jdbc:mysql://#{db_machine}/#{db_db}?user=#{db_user}&password=#{db_password}")
+    DB = Sequel.connect("jdbc:mysql://#{db_machine}/#{db_db}?user=#{db_user}&password=#{db_password}&useTimezone=true&serverTimezone=UTC")
   end
 end
 


### PR DESCRIPTION
Change the mechanism for querying HF database as follows:
  * Split querie components up into methods for readability
  * Do a single UNION query instead of two separate queries
  * Use DB connection from HathiTrust::DBH instead of rolling our own
  * Adjust HathiTrust::DBH to add timezone information to connection string
  * Downcase collection code before feeding it into the collection-code-to-original-from mapping (original code returning nil most of the time due to case mismatch)