### PR TITLE
Add support for sorting by Best Bet rank.

### DIFF
--- a/indexers/umich.rb
+++ b/indexers/umich.rb
@@ -78,6 +78,16 @@ to_field 'hlb3Delimited', extract_marc('050ab:082a:090ab:099a:086a:086z:852|0*|h
   acc.map! { |c| c.to_a.join(' | ') }
 end
 
+require 'best_bets'
+
+BestBets.load('https://apps.lib.umich.edu/admin/bestbets/export').each_term do |term|
+  to_field(term.to_field) do |rec, acc|
+    term.on(rec[term.marc].value) do |rank|
+      acc << rank
+    end
+  end
+end
+
 
 # UMich-specific stuff based on Hathitrust. For Mirlyn, we say something is
 # htso iff it has no ht fulltext, and no other holdings. Basically, this is

--- a/lib/best_bets.rb
+++ b/lib/best_bets.rb
@@ -1,0 +1,10 @@
+require 'json'
+require 'httpclient'
+require_relative 'best_bets/list'
+require_relative 'best_bets/term'
+
+module BestBets
+  def self.load(url)
+    BestBets::List.new(JSON.parse(HTTPClient.new.get(url).body))
+  end
+end

--- a/lib/best_bets/list.rb
+++ b/lib/best_bets/list.rb
@@ -1,0 +1,19 @@
+module BestBets
+  class List
+
+    def initialize(data)
+      @terms = {}
+      data.each do |row|
+        (@terms[row['category']] ||= Term.new(row)).merge!(row)
+        @terms[row['category']].merge!(row)
+      end
+    end
+
+    def each_term
+      @terms.each_value do |term|
+        yield term
+      end
+    end
+
+  end
+end

--- a/lib/best_bets/term.rb
+++ b/lib/best_bets/term.rb
@@ -1,0 +1,27 @@
+module BestBets
+  class Term
+    def initialize(hsh = {})
+      @id = hsh['tid']
+      @name = hsh['category']
+      @rankings = {hsh['id'] => hsh['rank']}
+    end
+
+    def merge!(hsh = {})
+      return self unless hsh.has_key?('id') && hsh.has_key?('rank')
+      @rankings[hsh['id']] = hsh['rank']
+      self
+    end
+
+    def to_field
+      @name.downcase.gsub(/[^a-z'&]/, '_').gsub(/_+/, '_').sub(/_+$/, '') + '_bb'
+    end
+
+    def marc
+      "001"
+    end
+
+    def on(id)
+      yield @rankings[id] if @rankings.has_key?(id) && @rankings[id]
+    end
+  end
+end


### PR DESCRIPTION
This is for SEARCH-1288.  Browse by HLB/Academic Discipline for journals uses a sort by manually curated rank, then sort alphabetically.  Since the rank is category specific, that means one field for each category, thus the dynamic field.  This should end up creating a little more than 100 new fields, but they generally only have 0-5 items assigned, so probably fewer than 1000 records will have values assigned to any of these categories.