### PR TITLE
Set up callnumber fields to use lc_callnumber_simple in solr config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'sequel'
 gem 'httpclient'
 gem 'library_stdnums'
 gem "traject-marc4j_reader", "~> 1.0"
-gem "callnumber_collation", git: "https://github.com/billdueber/callnumber_collation", branch: 'main'
 
 if defined? JRUBY_VERSION
   gem 'naconormalizer'

--- a/indexers/umich.rb
+++ b/indexers/umich.rb
@@ -1,5 +1,4 @@
 require 'umich_traject'
-require 'callnumber_collation'
 
 ## OK, so one weird thing we need to do is have different ht_json docs for mirlyn vs hathitrust, since they have differently-formatted 974s. Pass in the :mirlyn symbol and the to_json will do the Right Thing.
 
@@ -13,15 +12,13 @@ to_field 'callnumber', extract_marc('852hij')
 to_field 'callnoletters', extract_marc('852hij:050ab:090ab', :first => true) do |rec, acc|
   unless acc.empty?
     m = /\A([A-Za-z]+)/.match(acc[0])
-    acc[0] = m[1] if m
+    acc[0] = m[1].upcase if m
   end
 end
 
 to_field 'callnosort' do |record, acc, context|
   if context.output_hash['callnumber']
-    orig = Array(context.output_hash['callnumber']).first
-    collatable = CallnumberCollation::LC.new(orig)
-    acc << collatable.collation_key
+    acc << context.output_hash['callnumber'].first
   end
 end
 


### PR DESCRIPTION
This essentially means removing any special processing from the
pre-processing of callnumbers (`callnumber`, `callnosort`)
since the server code will take care of it all now.