### PR TITLE
Attempt to deal with bad utf-8 in the multfile marc4j reader

### DIFF
--- a/lib/multifile_marc4j_reader.rb
+++ b/lib/multifile_marc4j_reader.rb
@@ -1,13 +1,29 @@
+# encoding: utf-8
 require 'traject/marc4j_reader'
+require 'marc'
+require 'stringio'
 
 module Traject
   class MultiFileMarc4JReader < Traject::Marc4JReader
 
     # @param [Traject::Reader]
     def initialize(input_stream, settings)
+      @settings = settings
       globs = get_and_validate_globs(settings)
       super
       @inputs = streams_from_globs(globs)
+    end
+
+
+    # We're getting some items from alma with encoding problems that manifest when
+    # trying to generate JSON. Because it's not already too slow to index, we'll
+    # do a vacuous #to_json on the record and capture the error for logging
+
+    def can_be_jsonified(r)
+      r.to_hash.to_json
+      :ok
+    rescue JSON::GeneratorError, Encoding::UndefinedConversionError => e
+      e
     end
 
     alias_method :old_each, :each
@@ -15,16 +31,36 @@ module Traject
     def each
       return to_enum(:each) unless block_given?
       @inputs.each do |stream|
-        logger.info("Processing #{stream.first}")
+        filename = stream.first
         @input_stream = stream.last
+        logger.info("Processing #{filename}")
+
         @internal_reader = create_marc_reader!
+        already_retried = false
+        i = 0
         self.old_each do |r|
-          yield r
+          i += 1
+          jsonifiable = can_be_jsonified(r)
+          if jsonifiable == :ok
+            already_retried = false
+            yield r
+          else
+            id = r["001"].value
+            if already_retried
+              logger.error "Skipping un-json-ifyable record #{id} (record #[i} in  #{filename}): #{jsonifiable}"
+            else
+              logger.warn "Scrubbing record #{id} (record #{i} in file #{filename}) and retrying due to #{jsonifiable.inspect}"
+              str = r.to_xml.to_s.scrub
+              r = MARC::XMLReader.new(StringIO.new(str)).first
+              redo
+            end
+          end
         end
       end
     end
 
     private
+
     def get_and_validate_globs(settings)
       globstr = settings['source_glob']
       globs = globstr.split(/\s*,\s*/)
@@ -32,8 +68,16 @@ module Traject
       globs
     end
 
+    def open_stream(filename)
+      if @settings["marc_source.encoding"] == "xml"
+        File.open(filename, 'r:utf-8')
+      else
+        File.open(filename, 'r')
+      end
+    end
+
     def streams_from_globs(globs)
-      streammap = globs.each_with_object({}) { |g, h| h[g] = Dir.glob(g).map{|f| [f, File.open(f, 'r')]}}
+      streammap = globs.each_with_object({}) { |g, h| h[g] = Dir.glob(g).map { |f| [f, open_stream(f)] } }
       streammap.each_pair do |g, s|
         if s.empty?
           logger.warn "Glob '#{g}' matched no files"


### PR DESCRIPTION
Note: This should be addressed deeper in the code, but this is good for now

Alma data has (at least once) given us xml with embedded hex codes instead of
properly-xml-encoded entities. This modifies the multifie marc4j reader as follows:

* The reader detects marc.format = "xml" and sets the encoding of the incoming files
  explicitly as UTF-8
* Before being yielded to the indexer, the reader does a spurious #to_json
  to force encoding issues to come to the forefront
* If there's an issue, an attempt is made to use String#scrub to scrub the file by
  turning the record _back_ into XML, scrubbing, and then re-reading it into a
  MARC::Record
* If _that_ also fails, log an error and skip to the next record

Log lines are of the form:

```
2021-07-02T16:26:12-04:00  WARN Scrubbing record 99184791418606381 (record 79257 in file 
/lit-prep/lib-search/data/xml/20210625/processed/bib_auth_2021062511_8744519880006381_new_8.xml) 
and retrying due to #<Encoding::UndefinedConversionError: "\xA9" ffom ASCII-8BIT to UTF-8>
```