### PR TITLE
Display fields `lc_subject_display` and `non_lc_subject_display`

### DIFF
--- a/bin/tindex
+++ b/bin/tindex
@@ -81,7 +81,8 @@ cmd="bundle exec traject
   -c $TDIR/readers/$READER.rb 
   -c $TDIR/writers/$WRITER.rb 
   -c $TDIR/indexers/common.rb 
-  -c $TDIR/indexers/common_ht.rb 
+  -c $TDIR/indexers/common_ht.rb
+  -c $TDIR/indexers/subject_topic.rb
   -c $TDIR/indexers/umich.rb 
   -s log.file=STDOUT 
   $filename"

--- a/bin/tindex_xml
+++ b/bin/tindex_xml
@@ -83,7 +83,8 @@ cmd="bundle exec traject
   -c $TDIR/readers/$READER.rb 
   -c $TDIR/writers/$WRITER.rb 
   -c $TDIR/indexers/common.rb 
-  -c $TDIR/indexers/common_ht.rb 
+  -c $TDIR/indexers/common_ht.rb
+  -c $TDIR/indexers/subject_topic.rb
   -c $TDIR/indexers/umich.rb 
   -c $TDIR/indexers/umich_alma.rb 
   -s log.file=STDOUT 

--- a/indexers/common.rb
+++ b/indexers/common.rb
@@ -302,37 +302,6 @@ to_field('title_author') do |r, acc, context|
   end
 end
 
-################################
-######## SUBJECT / TOPIC  ######
-################################
-
-# We get the full topic (LCSH), but currently want to ignore
-# entries that are FAST entries (those having second-indicator == 7)
-
-
-skip_FAST = ->(rec, field) do
-  field.indicator2 == '7' and field['2'] =~ /fast/
-end
-
-to_field "topic", extract_marc_unless(%w(
-  600a  600abcdefghjklmnopqrstuvxyz
-  610a  610abcdefghklmnoprstuvxyz
-  611a  611acdefghjklnpqstuvxyz
-  630a  630adefghklmnoprstvxyz
-  648a  648avxyz
-  650a  650abcdevxyz
-  651a  651aevxyz
-  653a  653abevyz
-  654a  654abevyz
-  655a  655abvxyz
-  656a  656akvxyz
-  657a  657avxyz
-  658a  658ab
-  662a  662abcdefgh
-  690a   690abcdevxyz
-
-  ), skip_FAST, :trim_punctuation => true)
-
 
 ###############################
 #### Genre / geography / dates

--- a/indexers/subject_topic.rb
+++ b/indexers/subject_topic.rb
@@ -1,0 +1,38 @@
+$:.unshift "#{File.dirname(__FILE__)}/../lib"
+
+require_relative '../lib/umich_traject'
+extend Traject::Macros::UMich::SubjectMacros
+
+################################
+######## SUBJECT / TOPIC  ######
+################################
+
+# We get the full topic (LCSH), but currently want to ignore
+# entries that are FAST entries (those having second-indicator == 7)
+
+
+skip_FAST = ->(rec, field) do
+  field.indicator2 == '7' and field['2'] =~ /fast/
+end
+
+to_field "topic", extract_marc_unless(%w(
+  600a  600abcdefghjklmnopqrstuvxyz
+  610a  610abcdefghklmnoprstuvxyz
+  611a  611acdefghjklnpqstuvxyz
+  630a  630adefghklmnoprstvxyz
+  648a  648avxyz
+  650a  650abcdevxyz
+  651a  651aevxyz
+  653a  653abevyz
+  654a  654abevyz
+  655a  655abvxyz
+  656a  656akvxyz
+  657a  657avxyz
+  658a  658ab
+  662a  662abcdefgh
+  690a   690abcdevxyz
+
+  ), skip_FAST, :trim_punctuation => true)
+
+to_field 'lc_subject_display', lcsh_subjects
+to_field 'non_lc_subject_display', non_lcsh_subjects

--- a/lib/ht_traject/ht_macros.rb
+++ b/lib/ht_traject/ht_macros.rb
@@ -34,7 +34,7 @@ module HathiTrust::Traject::Macros
     #
     # This isn't deep, deep magic, but it's not exactly intuitive.
     # Basically, we're opening up the eigenclass for this one
-    # instance and redefining the method that deterines if
+    # instance and redefining the method that determines if
     # a field matches the spec
     #
     # Most of it is copied from the original implementation

--- a/lib/umich_traject.rb
+++ b/lib/umich_traject.rb
@@ -1,4 +1,4 @@
-# MatchMaps
+
 require 'umich_traject/building_map'
 require 'umich_traject/location_map'
-
+require 'umich_traject/subject_macros'

--- a/lib/umich_traject/subject_macros.rb
+++ b/lib/umich_traject/subject_macros.rb
@@ -1,0 +1,56 @@
+## frozen_string_literal: true
+
+module Traject
+  module Macros
+    module UMich
+      module Subject
+      end
+    end
+  end
+end
+
+module Traject::Macros::UMich
+  module Subject
+
+    LOWER_LETTER_PAT = /\p{Lower}/
+    STRIP_PUNCT_PAT = /\A\p{Punct}*(.*?)\p{Punct}*\Z/
+
+    def self.normalize_subject(str)
+      STRIP_PUNCT_PAT.match(str)[1].gsub("/\s+/", ' ')
+    end
+
+    def self.eight_eighties_for(r, f)
+      vid = f['6']
+      if vid
+        r.fields('880').select { |eef| eef['6'].start_with? "#{f.tag}-#{vid.split("-").last}" }
+      else
+        []
+      end
+    end
+
+    def self.subject_string(field)
+      self.normalize_subject(field.subfields.select { |sf| LOWER_LETTER_PAT.match(sf.code) }.map(&:value).join(" -- "))
+    end
+
+    def self.subjects_by_ind2(r, ind2_pat)
+      fields = r.fields.select { |f| f.tag[0] == '6' and ind2_pat.match(f.indicator2) }
+      fields + fields.flat_map { |f| self.eight_eighties_for(r, f) }
+    end
+  end
+
+  module SubjectMacros
+
+    def lcsh_subjects
+      ->(r, acc) do
+        acc.replace Subject.subjects_by_ind2(r, /0/).map { |f| Subject.subject_string(f) }
+      end
+    end
+
+    def non_lcsh_subjects
+      ->(r, acc) do
+        acc.replace Subject.subjects_by_ind2(r, /[^0]/).map { |f| Subject.subject_string(f) }
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Added two subject fields (all 6XX) partitioned on indicator 2 == 0
or not. Includes 880 linked fields at the end of each list.

Pairs with https://github.com/mlibrary/library_solr_config/pull/10