### PR TITLE
marc4jfix

### DIFF
--- a/bin/tindex_xml
+++ b/bin/tindex_xml
@@ -18,7 +18,7 @@ then
   echo
   echo "...where"
   echo "  - 'writer' is the name of the writer config (in ht_traject/writers/, without the 'rb')"
-  echo "  - 'filename' is the name of the file of MARC records"
+  echo "  - 'filename' is the name of the file of MARC records or a (quoted!) filesystem glob for many files"
   echo "  - 'logfile' is the name of the log file"
   echo 
   echo "You can set the environment variable READER to the name of the reader config file (without"
@@ -37,14 +37,25 @@ export TMPDIR="${HERE}/logs"
 
 #READER=alephsequential
 #READER=xml
-READER=m4j
+READER=multim4j
 WRITER=$1
 
-filename=$2
-filebase=`basename "$filename"`
+filename_glob=$2
 
 logfile=$3
 [[ ! -z "$logfile" ]] && logfile=`realpath "$logfile"`
+
+# Better double-check to make sure we're not going to append our log stuff
+# to an xml file, which would happen if the caller forgets to quote
+# the glob
+
+if [[ "${logfile}" =~ .xml$ ]]; then
+  echo "Logfile is $logfile"
+  echo "Logfile (argument 3) seems to have an xml extension"
+  echo "Did you forget to quote the filename glob, resulting in"
+  echo "command-line expansion of filenames?"
+  exit 1
+fi
 
 # Pull in functions to find marc/del files
 source $SCRIPTDIR/utils.sh
@@ -77,7 +88,7 @@ cd $TDIR
 log "Getting collection map" $logfile
 # $JRUBY -S bundle exec $SCRIPTDIR/get_collection_map.rb
 
-log "Indexing from $filename with reader $READER into $WRITER ($SOLR_URL)" $logfile
+log "Indexing from ${filename_glob} with reader $READER into $WRITER ($SOLR_URL)" $logfile
 
 cmd="bundle exec traject 
   -c $TDIR/readers/$READER.rb 
@@ -86,6 +97,7 @@ cmd="bundle exec traject
   -c $TDIR/indexers/common_ht.rb 
   -c $TDIR/indexers/umich.rb 
   -c $TDIR/indexers/umich_alma.rb 
+  -s source_glob="${filename_glob}"
   -s log.file=STDOUT 
   $filename"
 

--- a/indexers/common.rb
+++ b/indexers/common.rb
@@ -18,6 +18,7 @@ extend Traject::UMichFormat::Macros
 require 'marc/fastxmlwriter'
 
 require 'marc_record_speed_monkeypatch'
+require 'marc4j_fix'
 
 UmichOverlap = if ENV['NODB']
                  require "ht_traject/no_db_mocks/ht_overlap"

--- a/lib/marc4j_fix.rb
+++ b/lib/marc4j_fix.rb
@@ -21,7 +21,8 @@ module MARC
           # if subfield.getCode is more than 255, subsequent .chr
           # would raise.
 
-          if sf_code !~ /[a-z0-9]/
+          #if sf_code !~ /[a-z0-9]/
+          if sf_code !~ /[\dA-Za-z!"#$%&'()*+,-.\/:;<=>?{}_^`~\[\]\\]/
             if @logger
               @logger.warn("Marc4JReader: Invalid MARC data, record id #{marc4j.getControlNumber}, field #{marc4j_data.tag}, invalid subfield code '#{sf_code}'. Skipping subfield, but continuing with record.")
             end

--- a/lib/marc4j_fix.rb
+++ b/lib/marc4j_fix.rb
@@ -1,0 +1,41 @@
+module MARC
+  class MARC4J
+
+    # Given a marc4j record, return a rubymarc record
+    # check for valid subfield code
+    def marc4j_to_rubymarc(marc4j)
+      rmarc = MARC::Record.new
+      rmarc.leader = marc4j.getLeader.marshal
+
+      marc4j.getControlFields.each do |marc4j_control|
+        rmarc.append( MARC::ControlField.new(marc4j_control.getTag(), marc4j_control.getData )  )
+      end
+
+      marc4j.getDataFields.each do |marc4j_data|
+        rdata = MARC::DataField.new(  marc4j_data.getTag,  marc4j_data.getIndicator1.chr, marc4j_data.getIndicator2.chr )
+
+        marc4j_data.getSubfields.each do |subfield|
+
+          sf_code = subfield.getCode.chr(Encoding::UTF_8)
+          # We assume Marc21, skip corrupted data
+          # if subfield.getCode is more than 255, subsequent .chr
+          # would raise.
+
+          if sf_code !~ /[a-z0-9]/
+            if @logger
+              @logger.warn("Marc4JReader: Invalid MARC data, record id #{marc4j.getControlNumber}, field #{marc4j_data.tag}, invalid subfield code '#{sf_code}'. Skipping subfield, but continuing with record.")
+            end
+            next
+          end
+
+          rsubfield = MARC::Subfield.new(subfield.getCode.chr, subfield.getData)
+          rdata.append rsubfield
+        end
+
+        rmarc.append rdata
+      end
+
+      return rmarc
+    end
+  end
+end

--- a/lib/multifile_marc4j_reader.rb
+++ b/lib/multifile_marc4j_reader.rb
@@ -1,13 +1,29 @@
+# encoding: utf-8
 require 'traject/marc4j_reader'
+require 'marc'
+require 'stringio'
 
 module Traject
   class MultiFileMarc4JReader < Traject::Marc4JReader
 
     # @param [Traject::Reader]
     def initialize(input_stream, settings)
+      @settings = settings
       globs = get_and_validate_globs(settings)
       super
       @inputs = streams_from_globs(globs)
+    end
+
+
+    # We're getting some items from alma with encoding problems that manifest when
+    # trying to generate JSON. Because it's not already too slow to index, we'll
+    # do a vacuous #to_json on the record and capture the error for logging
+
+    def can_be_jsonified(r)
+      r.to_hash.to_json
+      :ok
+    rescue JSON::GeneratorError, Encoding::UndefinedConversionError => e
+      e
     end
 
     alias_method :old_each, :each
@@ -15,16 +31,36 @@ module Traject
     def each
       return to_enum(:each) unless block_given?
       @inputs.each do |stream|
-        logger.info("Processing #{stream.first}")
+        filename = stream.first
         @input_stream = stream.last
+        logger.info("Processing #{filename}")
+
         @internal_reader = create_marc_reader!
+        already_retried = false
+        i = 0
         self.old_each do |r|
-          yield r
+          i += 1
+          jsonifiable = can_be_jsonified(r)
+          if jsonifiable == :ok
+            already_retried = false
+            yield r
+          else
+            id = r["001"].value
+            if already_retried
+              logger.error "Skipping un-json-ifyable record #{id} (record #[i} in  #{filename}): #{jsonifiable}"
+            else
+              logger.warn "Scrubbing record #{id} (record #{i} in file #{filename}) and retrying due to #{jsonifiable.inspect}"
+              str = r.to_xml.to_s.scrub
+              r = MARC::XMLReader.new(StringIO.new(str)).first
+              redo
+            end
+          end
         end
       end
     end
 
     private
+
     def get_and_validate_globs(settings)
       globstr = settings['source_glob']
       globs = globstr.split(/\s*,\s*/)
@@ -32,8 +68,16 @@ module Traject
       globs
     end
 
+    def open_stream(filename)
+      if @settings["marc_source.encoding"] == "xml"
+        File.open(filename, 'r:utf-8')
+      else
+        File.open(filename, 'r')
+      end
+    end
+
     def streams_from_globs(globs)
-      streammap = globs.each_with_object({}) { |g, h| h[g] = Dir.glob(g).map{|f| [f, File.open(f, 'r')]}}
+      streammap = globs.each_with_object({}) { |g, h| h[g] = Dir.glob(g).map { |f| [f, open_stream(f)] } }
       streammap.each_pair do |g, s|
         if s.empty?
           logger.warn "Glob '#{g}' matched no files"


### PR DESCRIPTION
monkey-patch mar4j4r to deal more correctly with marc codes that are more arbitrary utf-8

This replaces #13.