### PR TITLE
Records incorrectly marked as available online

### DIFF
--- a/indexers/umich_alma.rb
+++ b/indexers/umich_alma.rb
@@ -217,7 +217,7 @@ each_record do |r, context|
         else
           hol[:finding_aid] = false
         end
-        availability << 'avail_online'
+        availability << 'avail_online' if f.indicator2 == '1'
         hol_list << hol
 
       end


### PR DESCRIPTION
Records that aren't digitized are showing up as available online when they have links to finding aids.  Checking the second indicator might be sufficient.  Though I realize as I write this that we might also want to allow `indicator2 == '0'`. 