### PR TITLE
Clean up ht processing:

### DIFF
--- a/indexers/common.rb
+++ b/indexers/common.rb
@@ -56,18 +56,31 @@ to_field 'oclc', oclcnum('035a:035z')
 to_field 'record_source', record_source 	# set to alma or zephir, based on record id
 
 
-# for zephir records, check umich print holdings overlap file--skip is oclc number is found in file
+# for zephir records, check umich print holdings overlap file--skip if oclc number is found in file
 each_record do |rec, context|
+  id = context.output_hash['id']
   oclc_nums = context.output_hash['oclc']
-  context.clipboard[:ht][:overlap] = UmichOverlap.get_overlap(oclc_nums) 	# returns count of all records found (:count_all), and access=deny records (:count_etas)
+  #context.clipboard[:ht][:overlap] = UmichOverlap.get_overlap(oclc_nums) 	# returns count of all records found (:count_all), and access=deny records (:count_etas)
   if context.clipboard[:ht][:record_source] == 'zephir'
-    if context.clipboard[:ht][:overlap][:count_all] > 0
-      id = context.output_hash['id']
-      context.skip!("#{context.output_hash['id']} : zephir record skipped")
+    if record_is_umich(rec)
+      context.skip!("#{id} : zephir record skipped, HOL")
+    else 
+      # Since ETAS is not in effect, following only needed for zephir records 
+      context.clipboard[:ht][:overlap] = UmichOverlap.get_overlap(oclc_nums) 	# returns count of all records found (:count_all), and access=deny records (:count_etas)
+      if context.clipboard[:ht][:overlap][:count_all] > 0
+        context.skip!("#{id} : zephir record skipped, overlap")
+        logger.info("#{id} : zephir record skipped, overlap")
+      end
     end
   end
 end
   
+def record_is_umich(r)
+  return false unless r['HOL'] and r['HOL']['c']	# shouldn't occur
+  return true if r['HOL']['c'] == 'MIU'	
+  return false
+end
+
 to_field "allfields", extract_all_marc_values(to: '850') do |r, acc|
   acc.replace [acc.join(' ')] # turn it into a single string
 end

--- a/indexers/umich_alma.rb
+++ b/indexers/umich_alma.rb
@@ -62,7 +62,7 @@ each_record do |r, context|
     #cc_to_of = Traject::TranslationMap.new('ht/collection_code_to_original_from')
     # add hol for HT volumes
     items = Array.new()
-    etas_status = context.clipboard[:ht][:overlap][:count_etas] > 0 # make it a boolean
+    #etas_status = context.clipboard[:ht][:overlap][:count_etas] > 0 # make it a boolean
     r.each_by_tag('974') do |f|
       next unless f['u']
       item = Hash.new()
@@ -72,7 +72,8 @@ each_record do |r, context|
       item[:collection_code] = f['c']
       item[:source] = cc_to_of[f['c'].downcase]
       item[:access] = !!(item[:rights] =~ /^(pd|world|ic-world|cc|und-world)/)
-      item[:status] = statusFromRights(item[:rights], etas_status)
+      #item[:status] = statusFromRights(item[:rights], etas_status)
+      item[:status] = statusFromRights(item[:rights])
       items << item
     end
     if items.any?
@@ -89,7 +90,7 @@ each_record do |r, context|
         availability << 'avail_ht_fulltext' if item[:access]
         availability << 'avail_online' if item[:access]
       end
-      availability << 'avail_ht_etas' if context.clipboard[:ht][:overlap][:count_etas] > 0
+      #availability << 'avail_ht_etas' if context.clipboard[:ht][:overlap][:count_etas] > 0
     end
   else
     record_has_finding_aid = false
@@ -265,16 +266,17 @@ each_record do |r, context|
 
     # add hol for HT volumes
     bib_nums = Array.new()
+    bib_nums << '.' + context.output_hash['id'].first
     bib_nums << context.output_hash['aleph_id'].first if context.output_hash['aleph_id']
-    bib_nums << context.output_hash['id'].first
     oclc_nums = context.output_hash['oclc']
-    etas_status = context.clipboard[:ht][:overlap][:count_etas] > 0
+    #etas_status = context.clipboard[:ht][:overlap][:count_etas] > 0
     #hf_item_list = HathiTrust::Hathifiles.get_hf_info(oclc_nums, bib_nums, etas_status)
     hf_item_list = HathiFiles.get_hf_info(oclc_nums, bib_nums)
     if hf_item_list.any?
       hf_item_list = sortItems(hf_item_list)
       hf_item_list.each do |r|
-        r[:status] = statusFromRights(r[:rights], etas_status)
+        #r[:status] = statusFromRights(r[:rights], etas_status)
+        r[:status] = statusFromRights(r[:rights])
       end
       hol = Hash.new()
       hol[:library] = 'HathiTrust Digital Library'
@@ -288,7 +290,7 @@ each_record do |r, context|
         availability << 'avail_ht_fulltext' if item[:access]
         availability << 'avail_online' if item[:access]
       end
-      availability << 'avail_ht_etas' if context.clipboard[:ht][:overlap][:count_etas] > 0
+      #availability << 'avail_ht_etas' if context.clipboard[:ht][:overlap][:count_etas] > 0
     end
 
   end


### PR DESCRIPTION
  prefix alma record key with dot when searching hathifiles
  For zephir records, first check the record for a HOL field with MIU collection (subfield c), before checking overlap file for oclc numbers
  Comment out ETAS checks